### PR TITLE
Fix: fix the issue where left parentheses are missing in parsed QRC

### DIFF
--- a/archive/version.json
+++ b/archive/version.json
@@ -94,7 +94,7 @@
         {
             "name": "QRC Parser",
             "author": "wistaria",
-            "version": "0.1",
+            "version": "0.2",
             "uri": "qrc.js",
             "dependency": {
                 "libs": [

--- a/parser/qrc.js
+++ b/parser/qrc.js
@@ -2,7 +2,7 @@ import * as decoder from "parser_ext.so";
 
 export function getConfig(cfg) {
     cfg.name = "QRC Parser";
-    cfg.version = "0.1";
+    cfg.version = "0.2";
     cfg.author = "wistaria";
     cfg.parsePlainText = false;
     cfg.fileType = "qrc";

--- a/parser/qrc.js
+++ b/parser/qrc.js
@@ -53,35 +53,9 @@ function qrcToLrc(xmlText) {
     if (qrcText == null)
         return null;
 
-    var lyricText = "";
-    var matches;
-    var metaRegex = /^\[(\S+):(\S+)\]$/;
-    var tsRegex = /^\[(\d+),(\d+)\]/;
-    var ts2Regex = /([^(^\]]*)\((\d+),(\d+)\)/g;
-    var lines = qrcText.split(/[\r\n]/);
-    for (const line of lines) {
-        //console.log(line);
-        if (matches = metaRegex.exec(line)) { // meta info
-            lyricText += matches[0] + "\r\n";
-        } else if (matches = tsRegex.exec(line)) {
-            let lyricLine = "";
-            let baseTime = parseInt(matches[1]);
-            let duration = parseInt(matches[2]);
-            lyricLine += "[" + formatTime(baseTime) + "]";
-            lyricLine += "<" + formatTime(baseTime) + ">";
-            // parse sub-timestamps
-            let subMatches;
-            while (subMatches = ts2Regex.exec(line)) {
-                var startTime = parseInt(subMatches[2]);
-                let offset = parseInt(subMatches[3]);
-                let subWord = subMatches[1];
-                lyricLine += subWord + "<" + formatTime(startTime + offset) + ">";
-            }
-            lyricText += lyricLine + "\r\n";
-        }
-    }
-
-    return lyricText;
+    return qrcText
+        .replace(/^\[(\d+),(\d+)\]/gm, (_, base, __) => `[${formatTime(+base)}]<${formatTime(+base)}>`)
+        .replace(/\((\d+),(\d+)\)/g, (_, start, offset) => `<${formatTime(+start + +offset)}>`);
 }
 
 function zpad(n) {


### PR DESCRIPTION
在解析QRC时，原有的正则表达式会吞掉左括号，如下图中Piano Style的左边与川田まみ的左边均应有括号。

![image](https://user-images.githubusercontent.com/13536040/224691260-fd9eea0d-07f4-42a2-8dfc-6fdb1402e4e3.png)

本PR修复了这个问题，如下图。

![image](https://user-images.githubusercontent.com/13536040/224691741-96db8633-f84f-4308-a131-23e64c9c3a67.png)
